### PR TITLE
Fixed instance creation error when name too long

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,7 +36,7 @@ export USER="${USER:-imagebuilder}"
 # Multiple arguments can be passed and has to be separated by a comma.
 readonly TESTS_CUSTOM_METADATA="${TESTS_CUSTOM_METADATA:-}"
 
-readonly INSTANCE="imagebuilder-tests-${PRE_IMAGE}-${RANDOM}"
+readonly INSTANCE ="$(echo "imagebuilder-tests-${PRE_IMAGE}-${RANDOM}" | md5sum | awk '{ print $1 }')"
 # $IMAGEBUILDER_TEST_DIR: temporary dir on vm.
 readonly IMAGEBUILDER_TEST_DIR=$(mktemp --dry-run /tmp/imagebuilder-tests.XXXXXX)
 
@@ -55,10 +55,10 @@ echo "--> Creating a temporary instance (${INSTANCE}) ..."
 gcloud_output="$(gcloud compute instances create "${INSTANCE}" \
   --image="${PRE_IMAGE}" \
   --zone="${ZONE}" \
-  --description="New instance created by imagebuilder tests" \
+  --description="New instance created by VM Imagebuilder tests" \
   --metadata=block-project-ssh-keys=true,ssh-keys="${USER}:$(cat "${PUBLIC_SSH_KEY}")","${TESTS_CUSTOM_METADATA}" \
   --machine-type=n1-standard-1 \
-  --labels=auto=test \
+  --labels=auto=test,image=${PRE_IMAGE},instance=vm_imagebuilder_tests \
   --tags=imagebuilder-workers \
   --format=text)"
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -58,7 +58,7 @@ gcloud_output="$(gcloud compute instances create "${INSTANCE}" \
   --description="New instance created by VM Imagebuilder tests" \
   --metadata=block-project-ssh-keys=true,ssh-keys="${USER}:$(cat "${PUBLIC_SSH_KEY}")","${TESTS_CUSTOM_METADATA}" \
   --machine-type=n1-standard-1 \
-  --labels=auto=test,image=${PRE_IMAGE},instance=vm_imagebuilder_tests \
+  --labels=auto=test,image=${PRE_IMAGE},instance=vm-imagebuilder-tests \
   --tags=imagebuilder-workers \
   --format=text)"
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,7 +36,7 @@ export USER="${USER:-imagebuilder}"
 # Multiple arguments can be passed and has to be separated by a comma.
 readonly TESTS_CUSTOM_METADATA="${TESTS_CUSTOM_METADATA:-}"
 
-readonly INSTANCE ="$(echo "imagebuilder-tests-${PRE_IMAGE}-${RANDOM}" | md5sum | awk '{ print $1 }')"
+readonly INSTANCE=$(echo "imagebuilder-tests-${PRE_IMAGE}-${RANDOM}" | md5sum | awk '{ print $1 }')
 # $IMAGEBUILDER_TEST_DIR: temporary dir on vm.
 readonly IMAGEBUILDER_TEST_DIR=$(mktemp --dry-run /tmp/imagebuilder-tests.XXXXXX)
 


### PR DESCRIPTION
For images that have long names, imagebuilder will add on prefix and suffixes to the name and may result in a name over 64 characters long. This will result in the following error:

ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid value for field 'resource.name': 'imagebuilder-tests-<pre_image_name>-16456'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'

A fix for this is to md5sum the instance name and add readable labels to the instance if troubleshooting is needed.