### PR TITLE
Removing calls to disable google services since they are not loaded.

### DIFF
--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -79,10 +79,6 @@ echo "--> Stopping syslog service..."
 systemctl disable rsyslog.service
 systemctl stop rsyslog.service
 systemctl enable rsyslog.service
-
-echo "--> Stopping Google services..."
-systemctl stop google-accounts-daemon.service
-systemctl stop google-instance-setup.service
 """
 
 VERIFY_SHUTDOWN_SCRIPT = r"""

--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -79,6 +79,9 @@ echo "--> Stopping syslog service..."
 systemctl disable rsyslog.service
 systemctl stop rsyslog.service
 systemctl enable rsyslog.service
+
+echo "--> Stopping Google services..."
+systemctl stop google-guest-agent.service
 """
 
 VERIFY_SHUTDOWN_SCRIPT = r"""

--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -83,6 +83,8 @@ systemctl enable rsyslog.service
 echo "--> Stopping Google services..."
 # We need to stop google services to avoid accidental creation of
 # by the account daemon
+# Reference to google-guest-agent 
+# https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine
 systemctl stop google-guest-agent.service
 """
 

--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -81,14 +81,9 @@ systemctl stop rsyslog.service
 systemctl enable rsyslog.service
 
 echo "--> Stopping Google services..."
-# See https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#configuration
-instance_config=/etc/default/instance_configs.cfg.template
-cat << EOF > "$instance_config"
-[Daemons]
-accounts_daemon = false
-EOF
-/usr/bin/google_instance_setup
-rm "$instance_config"
+# We need to stop google services to avoid accidental creation of
+# by the account daemon
+systemctl stop google-guest-agent.service
 """
 
 VERIFY_SHUTDOWN_SCRIPT = r"""

--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -72,7 +72,7 @@ find /root/ -mindepth 1 ! -name .profile ! -name .bashrc -delete
 
 STOP_SERVICES_SCRIPT = r"""
 echo "--> Stopping syslog service..."
-# Syslog is restarts on failure by default. Needed actions:
+# Syslog is restarted on failure by default. Needed actions:
 #  - disable
 #  - stop
 #  - enable (syslog is still stopped till next restart)
@@ -81,7 +81,14 @@ systemctl stop rsyslog.service
 systemctl enable rsyslog.service
 
 echo "--> Stopping Google services..."
-systemctl stop google-guest-agent.service
+# See https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#configuration
+instance_config=/etc/default/instance_configs.cfg.template
+cat << EOF > "$instance_config"
+[Daemons]
+accounts_daemon = false
+EOF
+/usr/bin/google_instance_setup
+rm "$instance_config"
 """
 
 VERIFY_SHUTDOWN_SCRIPT = r"""

--- a/scripts/packergen.py
+++ b/scripts/packergen.py
@@ -82,7 +82,7 @@ systemctl enable rsyslog.service
 
 echo "--> Stopping Google services..."
 # We need to stop google services to avoid accidental creation of
-# by the account daemon
+# users by the account daemon
 # Reference to google-guest-agent 
 # https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine
 systemctl stop google-guest-agent.service


### PR DESCRIPTION
The services are not loaded in the instance:
google-accounts-daemon.service	
google-instance-setup.service

The command to stop them fail with:
```
Failed to stop google-accounts-daemon.service: Unit google-accounts-daemon.service not loaded
```